### PR TITLE
v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.5.6
+
+* fix: disk template to use {{.CheckID}} for check_id attribute
+
 # v0.5.5 [CIRC-4272]
 
 * fix: correct rc.conf agent name for freebsd

--- a/content/templates/graph-disk.toml
+++ b/content/templates/graph-disk.toml
@@ -48,7 +48,7 @@ datapoints = [
     {
         "alpha": "0.3",
         "axis": "l",
-        "check_id": null,
+        "check_id": {{.CheckID}},
         "color": "#4fa18e",
         "data_formula": null,
         "derive": "counter",
@@ -68,7 +68,7 @@ datapoints = [
     {
         "alpha": "0.3",
         "axis": "l",
-        "check_id": null,
+        "check_id": {{.CheckID}},
         "color": "#657aa6",
         "data_formula": "=-1 * VAL",
         "derive": "counter",
@@ -88,7 +88,7 @@ datapoints = [
     {
         "alpha": "0.3",
         "axis": "r",
-        "check_id": null,
+        "check_id": {{.CheckID}},
         "color": "#b5c52d",
         "data_formula": null,
         "derive": "counter",
@@ -108,7 +108,7 @@ datapoints = [
     {
         "alpha": "0.3",
         "axis": "r",
-        "check_id": null,
+        "check_id": {{.CheckID}},
         "color": "#8e69a2",
         "data_formula": "=-1 * VAL",
         "derive": "counter",


### PR DESCRIPTION
* fix: disk template to use `{{.CheckID}}` for `check_id` attribute